### PR TITLE
PR: Missing specification in `pyproject.toml` to make `kite_provider` discoverable

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -75,3 +75,6 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest kite_provider -vv

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -71,3 +71,6 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest kite_provider -vv

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -69,3 +69,6 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest kite_provider -vv

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use this completions provider you will need to install Spyder 6 (at least 6.0
 
 To install the provider package, you can use `pip` with something like:
 
-    pip install git+https://github.com/spyder-ide/kite-provider.git@v0.1.0
+    pip install git+https://github.com/spyder-ide/kite-provider.git@v0.2.0
 
 **Note:** Support for Kite is not available anymore. The code here is meant to be used for demonstration proposes only, using it could brake your Spyder setup or make Spyder unstable! Use/install at your own risk.
 

--- a/kite_provider/parsing/tests/test_parsing.py
+++ b/kite_provider/parsing/tests/test_parsing.py
@@ -4,8 +4,7 @@
 # Licensed under the terms of the MIT License
 
 
-from parsing import (
-    find_returning_function_path)
+from kite_provider.parsing import find_returning_function_path
 
 
 def test_find_returning_function_path():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kite-provider"
-version = "0.1.0"
+version = "0.2.0"
 description = "Kite completions provider for Spyder"
 authors = [
     {name = "Spyder Project Contributors", email = "spyder.python@gmail.com"},
@@ -34,6 +34,7 @@ Homepage = "https://github.com/spyder-ide/kite-provider"
 kite = "kite_provider.provider:KiteProvider"
 
 [tool.setuptools]
-py-modules = []
+packages = ["kite_provider"]
+py-modules = ["__init__"]
 license-files = ["LICENSE"]
 include-package-data = false


### PR DESCRIPTION
* Erroneous config in `pyproject.toml` causes the package to not be importable (installation works but then trying to import the package fails)
* Fix test file and add steps to run tests on CI

Note: New release with the fix needs to be done after merging this